### PR TITLE
(fix) zmk board revision name for nice_nano_v2 is now nice_nano

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -18,9 +18,9 @@
 #
 ---
 include:
-  - board: nice_nano_v2
+  - board: nice_nano
     shield: corne_left
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
-  - board: nice_nano_v2
+  - board: nice_nano
     shield: corne_right


### PR DESCRIPTION
Build failed today and I found ZMK has an update for board revisions. My board seems to be fine so far flashed with this change.

Hope it helps.

For reference:
https://zmk.dev/blog/2025/12/09/zephyr-4-1#:~:text=nice%5Fnano%5Fv2%20%2D%3E%20nice%5Fnano%402%2E0%2E0%20%28short%3A%20nice%5Fnano%29

