### PR TITLE
feat: revert LED work, add Mac-flavored GACS home row mods

### DIFF
--- a/config/corne.conf
+++ b/config/corne.conf
@@ -1,6 +1,9 @@
-# Uncomment the following lines to enable the Corne RGB Underglow
-# CONFIG_ZMK_RGB_UNDERGLOW=y
-# CONFIG_WS2812_STRIP=y
+# RGB Underglow enabled
+CONFIG_ZMK_RGB_UNDERGLOW=y
+CONFIG_WS2812_STRIP=y
 
-# Uncomment the following line to enable the Corne OLED Display
+# Start with RGB off to save battery (toggle with Adjust+Q)
+CONFIG_ZMK_RGB_UNDERGLOW_ON_START=n
+
+# OLED Display enabled
 CONFIG_ZMK_DISPLAY=y

--- a/config/corne.conf
+++ b/config/corne.conf
@@ -1,14 +1,6 @@
-# RGB Underglow enabled and ON at boot
-CONFIG_ZMK_RGB_UNDERGLOW=y
-CONFIG_WS2812_STRIP=y
-CONFIG_ZMK_RGB_UNDERGLOW_ON_START=y
+# Uncomment the following lines to enable the Corne RGB Underglow
+# CONFIG_ZMK_RGB_UNDERGLOW=y
+# CONFIG_WS2812_STRIP=y
 
-# Don't auto-off when USB disconnects or on idle
-CONFIG_ZMK_RGB_UNDERGLOW_AUTO_OFF_IDLE=n
-CONFIG_ZMK_RGB_UNDERGLOW_AUTO_OFF_USB=n
-
-# External power on at boot (needed for LED power rail)
-CONFIG_ZMK_EXT_POWER=y
-
-# OLED Display enabled
+# Uncomment the following line to enable the Corne OLED Display
 CONFIG_ZMK_DISPLAY=y

--- a/config/corne.conf
+++ b/config/corne.conf
@@ -1,9 +1,14 @@
-# RGB Underglow enabled
+# RGB Underglow enabled and ON at boot
 CONFIG_ZMK_RGB_UNDERGLOW=y
 CONFIG_WS2812_STRIP=y
+CONFIG_ZMK_RGB_UNDERGLOW_ON_START=y
 
-# Start with RGB off to save battery (toggle with Adjust+Q)
-CONFIG_ZMK_RGB_UNDERGLOW_ON_START=n
+# Don't auto-off when USB disconnects or on idle
+CONFIG_ZMK_RGB_UNDERGLOW_AUTO_OFF_IDLE=n
+CONFIG_ZMK_RGB_UNDERGLOW_AUTO_OFF_USB=n
+
+# External power on at boot (needed for LED power rail)
+CONFIG_ZMK_EXT_POWER=y
 
 # OLED Display enabled
 CONFIG_ZMK_DISPLAY=y

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -7,55 +7,83 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/rgb.h>
-#include <dt-bindings/zmk/ext_power.h>
+
+// Corne key-position map (3x6+3 per side):
+//
+//   0  1  2  3  4  5        6  7  8  9 10 11
+//  12 13 14 15 16 17       18 19 20 21 22 23
+//  24 25 26 27 28 29       30 31 32 33 34 35
+//           36 37 38       39 40 41
 
 / {
-        conditional_layers {
-                compatible = "zmk,conditional-layers";
-                tri_layer {
-                        if-layers = <1 2>;
-                        then-layer = <3>;
+        behaviors {
+                // Home-row mods, left hand. Triggers only on opposite-hand keys
+                // + opposite-hand thumbs, so same-hand rolls fall back to tap.
+                hml: home_row_mod_left {
+                        compatible = "zmk,behavior-hold-tap";
+                        #binding-cells = <2>;
+                        tapping-term-ms = <220>;
+                        quick-tap-ms = <175>;
+                        require-prior-idle-ms = <150>;
+                        flavor = "balanced";
+                        hold-trigger-on-release;
+                        bindings = <&kp>, <&kp>;
+                        hold-trigger-key-positions = <
+                                 6  7  8  9 10 11
+                                18 19 20 21 22 23
+                                30 31 32 33 34 35
+                                39 40 41
+                        >;
+                };
+
+                // Home-row mods, right hand.
+                hmr: home_row_mod_right {
+                        compatible = "zmk,behavior-hold-tap";
+                        #binding-cells = <2>;
+                        tapping-term-ms = <220>;
+                        quick-tap-ms = <175>;
+                        require-prior-idle-ms = <150>;
+                        flavor = "balanced";
+                        hold-trigger-on-release;
+                        bindings = <&kp>, <&kp>;
+                        hold-trigger-key-positions = <
+                                 0  1  2  3  4  5
+                                12 13 14 15 16 17
+                                24 25 26 27 28 29
+                                36 37 38
+                        >;
                 };
         };
 
         keymap {
                 compatible = "zmk,keymap";
 
+                // GACS home row mods (Mac):
+                //   A=Cmd  S=Opt  D=Ctrl  F=Shift   J=Shift  K=Ctrl  L=Opt  ;=Cmd
                 default_layer {
                         bindings = <
-   &kp TAB   &kp Q &kp W &kp E &kp R &kp T   &kp Y &kp U  &kp I     &kp O   &kp P    &kp BSPC
-   &kp LCTRL &kp A &kp S &kp D &kp F &kp G   &kp H &kp J  &kp K     &kp L   &kp SEMI &kp SQT
-   &kp LSHFT &kp Z &kp X &kp C &kp V &kp B   &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &kp ESC
-                  &kp LGUI &mo 1 &kp SPACE   &kp RET &mo 2 &kp RALT
+   &kp TAB   &kp Q       &kp W       &kp E         &kp R         &kp T       &kp Y      &kp U         &kp I         &kp O       &kp P            &kp BSPC
+   &kp LCTRL &hml LGUI A &hml LALT S &hml LCTRL D  &hml LSHFT F  &kp G       &kp H      &hmr RSHFT J  &hmr RCTRL K  &hmr LALT L &hmr RGUI SEMI   &kp SQT
+   &kp LSHFT &kp Z       &kp X       &kp C         &kp V         &kp B       &kp N      &kp M         &kp COMMA     &kp DOT     &kp FSLH         &kp ESC
+                                              &kp LGUI &mo 1 &kp SPACE   &kp RET &mo 2 &kp RALT
                         >;
                 };
 
                 lower_layer {
                         bindings = <
-   &kp TAB    &kp N1       &kp N2       &kp N3       &kp N4       &kp N5         &kp N6   &kp N7   &kp N8 &kp N9    &kp N0 &kp BSPC
-   &bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4   &kp LEFT &kp DOWN &kp UP &kp RIGHT &trans &trans
-   &studio_unlock  &studio_unlock &trans &trans     &trans       &trans         &trans   &trans   &trans &trans    &trans &trans
-                                  &kp LGUI &trans &kp SPACE   &kp RET &trans   &kp RALT
+   &kp TAB        &kp N1         &kp N2       &kp N3       &kp N4       &kp N5         &kp N6   &kp N7   &kp N8 &kp N9    &kp N0 &kp BSPC
+   &bt BT_CLR     &bt BT_SEL 0   &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4   &kp LEFT &kp DOWN &kp UP &kp RIGHT &trans &trans
+   &studio_unlock &studio_unlock &trans       &trans       &trans       &trans         &trans   &trans   &trans &trans    &trans &trans
+                                              &kp LGUI &trans &kp SPACE   &kp RET &trans &kp RALT
                         >;
                 };
 
                 raise_layer {
                         bindings = <
-   &kp  TAB  &kp EXCL &kp AT &kp HASH &kp DLLR &kp PRCNT   &kp CARET &kp AMPS  &kp ASTRK &kp LPAR &kp RPAR &kp BSPC
+   &kp TAB   &kp EXCL &kp AT &kp HASH &kp DLLR &kp PRCNT   &kp CARET &kp AMPS  &kp ASTRK &kp LPAR &kp RPAR &kp BSPC
    &kp LCTRL &trans   &trans &trans   &trans   &trans      &kp MINUS &kp EQUAL &kp LBKT  &kp RBKT &kp BSLH &kp GRAVE
    &kp LSHFT &trans   &trans &trans   &trans   &trans      &kp UNDER &kp PLUS  &kp LBRC  &kp RBRC &kp PIPE &kp TILDE
-                             &kp LGUI &trans   &kp SPACE   &kp RET   &trans    &kp RALT
-                        >;
-                };
-
-                adjust_layer {
-// |  TOG  | EFF+ | EFF- | HUE+ | HUE- | BRI+ |   | BRI- | SPD+ | SPD- | SAT+ | SAT- | EXTPWR |
-                        bindings = <
-   &rgb_ug RGB_TOG  &rgb_ug RGB_EFF  &rgb_ug RGB_EFR  &rgb_ug RGB_HUI  &rgb_ug RGB_HUD  &rgb_ug RGB_BRI    &rgb_ug RGB_BRD  &rgb_ug RGB_SPI  &rgb_ug RGB_SPD  &rgb_ug RGB_SAI  &rgb_ug RGB_SAD  &ext_power EP_TOG
-   &trans           &trans           &trans           &trans           &trans           &trans              &trans           &trans           &trans           &trans           &trans           &trans
-   &trans           &trans           &trans           &trans           &trans           &trans              &trans           &trans           &trans           &trans           &trans           &trans
-                                                     &trans           &trans           &trans              &trans           &trans           &trans
+                             &kp LGUI &trans &kp SPACE     &kp RET &trans &kp RALT
                         >;
                 };
         };

--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -7,17 +7,22 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/rgb.h>
+#include <dt-bindings/zmk/ext_power.h>
 
 / {
+        conditional_layers {
+                compatible = "zmk,conditional-layers";
+                tri_layer {
+                        if-layers = <1 2>;
+                        then-layer = <3>;
+                };
+        };
+
         keymap {
                 compatible = "zmk,keymap";
 
                 default_layer {
-// -----------------------------------------------------------------------------------------
-// |  TAB |  Q  |  W  |  E  |  R  |  T  |   |  Y  |  U   |  I  |  O  |  P  | BKSP |
-// | CTRL |  A  |  S  |  D  |  F  |  G  |   |  H  |  J   |  K  |  L  |  ;  |  '   |
-// | SHFT |  Z  |  X  |  C  |  V  |  B  |   |  N  |  M   |  ,  |  .  |  /  | ESC  |
-//                    | GUI | LWR | SPC |   | ENT | RSE  | ALT |
                         bindings = <
    &kp TAB   &kp Q &kp W &kp E &kp R &kp T   &kp Y &kp U  &kp I     &kp O   &kp P    &kp BSPC
    &kp LCTRL &kp A &kp S &kp D &kp F &kp G   &kp H &kp J  &kp K     &kp L   &kp SEMI &kp SQT
@@ -25,31 +30,32 @@
                   &kp LGUI &mo 1 &kp SPACE   &kp RET &mo 2 &kp RALT
                         >;
                 };
+
                 lower_layer {
-// -----------------------------------------------------------------------------------------
-// |  TAB |  1  |  2  |  3  |  4  |  5  |   |  6  |  7  |  8  |  9  |  0  | BKSP |
-// | BTCLR| BT1 | BT2 | BT3 | BT4 | BT5 |   | LFT | DWN |  UP | RGT |     |      |
-// | SHFT |     |     |     |     |     |   |     |     |     |     |     |      |
-//                    | GUI |     | SPC |   | ENT |     | ALT |
                         bindings = <
    &kp TAB    &kp N1       &kp N2       &kp N3       &kp N4       &kp N5         &kp N6   &kp N7   &kp N8 &kp N9    &kp N0 &kp BSPC
    &bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4   &kp LEFT &kp DOWN &kp UP &kp RIGHT &trans &trans
-   &studio_unlock  &studio_unlock       &trans       &trans       &trans       &trans         &trans   &trans   &trans &trans    &trans &trans
-                                    &kp LGUI     &trans       &kp SPACE      &kp RET  &trans   &kp RALT
+   &studio_unlock  &studio_unlock &trans &trans     &trans       &trans         &trans   &trans   &trans &trans    &trans &trans
+                                  &kp LGUI &trans &kp SPACE   &kp RET &trans   &kp RALT
                         >;
                 };
 
                 raise_layer {
-// -----------------------------------------------------------------------------------------
-// |  TAB |  !  |  @  |  #  |  $  |  %  |   |  ^  |  &  |  *  |  (  |  )  | BKSP |
-// | CTRL |     |     |     |     |     |   |  -  |  =  |  [  |  ]  |  \  |  `   |
-// | SHFT |     |     |     |     |     |   |  _  |  +  |  {  |  }  | "|" |  ~   |
-//                    | GUI |     | SPC |   | ENT |     | ALT |
                         bindings = <
    &kp  TAB  &kp EXCL &kp AT &kp HASH &kp DLLR &kp PRCNT   &kp CARET &kp AMPS  &kp ASTRK &kp LPAR &kp RPAR &kp BSPC
    &kp LCTRL &trans   &trans &trans   &trans   &trans      &kp MINUS &kp EQUAL &kp LBKT  &kp RBKT &kp BSLH &kp GRAVE
    &kp LSHFT &trans   &trans &trans   &trans   &trans      &kp UNDER &kp PLUS  &kp LBRC  &kp RBRC &kp PIPE &kp TILDE
                              &kp LGUI &trans   &kp SPACE   &kp RET   &trans    &kp RALT
+                        >;
+                };
+
+                adjust_layer {
+// |  TOG  | EFF+ | EFF- | HUE+ | HUE- | BRI+ |   | BRI- | SPD+ | SPD- | SAT+ | SAT- | EXTPWR |
+                        bindings = <
+   &rgb_ug RGB_TOG  &rgb_ug RGB_EFF  &rgb_ug RGB_EFR  &rgb_ug RGB_HUI  &rgb_ug RGB_HUD  &rgb_ug RGB_BRI    &rgb_ug RGB_BRD  &rgb_ug RGB_SPI  &rgb_ug RGB_SPD  &rgb_ug RGB_SAI  &rgb_ug RGB_SAD  &ext_power EP_TOG
+   &trans           &trans           &trans           &trans           &trans           &trans              &trans           &trans           &trans           &trans           &trans           &trans
+   &trans           &trans           &trans           &trans           &trans           &trans              &trans           &trans           &trans           &trans           &trans           &trans
+                                                     &trans           &trans           &trans              &trans           &trans           &trans
                         >;
                 };
         };


### PR DESCRIPTION
## Summary

- Reverts the three RGB-underglow commits (LEDs never worked physically)
- Adds Home Row Mods using GACS scheme, Mac-flavored (`GUI = Cmd`, `Alt = Opt`)
- Tuning targeted for moderate typing speed (~44 WPM): `tapping-term-ms=220`, `quick-tap-ms=175`, `require-prior-idle-ms=150`, `flavor=balanced`, `hold-trigger-on-release` enabled

## Base layer (home row mods active)

| Side | Outer | | | | Inner |
|---|---|---|---|---|---|
| Left | **A**=Cmd | **S**=Opt | **D**=Ctrl | **F**=Shift | G |
| Right | H | **J**=Shift | **K**=Ctrl | **L**=Opt | **;**=Cmd |

Same-hand sequences (`df`, `jk`, etc.) fall back to plain taps because `hold-trigger-key-positions` only includes opposite-hand keys and thumbs.

## Test plan

- [ ] CI build passes for `corne_left` (with ZMK Studio) and `corne_right`
- [ ] Auto-drawn keymap-drawer SVG updates and looks correct
- [ ] Flash both halves, type a few sentences — verify no accidental Cmd/Shift triggers
- [ ] Hold `A` ~250ms, then press another key → confirm Cmd modifier engages